### PR TITLE
update link to the correct issues page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 We welcome all contributions to this project!
 If you notice a bug, or have a feature request,
-please open up an issue [here](https://github.com/UBC-DSCI/REPOSITORY_NAME/issues).
+please open up an issue [here](https://github.com/UBC-DSCI-310-2025W2/dsci-310-group-16/issues).
 If you'd like to contribute a feature or bug fix,
 you can fork our repo and submit a pull request.
 We will review pull requests within 7 days.


### PR DESCRIPTION
Our current link doesn’t work. I’ve updated it to the correct issues page in our repository.